### PR TITLE
Redesign hero section layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -81,27 +81,28 @@
   <!-- Hero -->
   <header class="hero" id="home">
     <canvas id="particles-canvas"></canvas>
-    <div class="hero-content container">
-      <img class="avatar" src="assets/image.png" alt="Sowmya Guda" loading="lazy" width="240" height="240" />
-      <h1 class="display-3 fw-bold">Hi, I'm <span class="text-gradient">Sowmya</span></h1>
-      <p class="lead mb-3"><span id="typed"></span><span class="typed-cursor">|</span></p>
-      <p class="tagline">I build reliable, data-driven products that feel delightful.</p>
-      <div class="mt-4 d-flex gap-3 flex-wrap justify-content-center">
-        <a href="#projects" class="btn btn-primary btn-pill"><i class="fa-solid fa-rocket me-2"></i>View Projects</a>
-        <a href="#contact" class="btn btn-outline-light btn-pill"><i class="fa-solid fa-message me-2"></i>Get in Touch</a>
-        <a id="resumeBtn" href="assets/resume.pdf" download class="btn btn-outline-light btn-pill d-none"><i class="fa-solid fa-download me-2"></i>Download Resume</a>
+    <div class="hero-content container d-flex flex-column flex-md-row align-items-center justify-content-between text-center text-md-start">
+      <div class="hero-text mb-4 mb-md-0">
+        <h1 class="display-3 fw-bold">Hi, I'm <span class="text-gradient">Sowmya</span></h1>
+        <p class="lead mb-3"><span id="typed"></span><span class="typed-cursor">|</span></p>
+        <p class="tagline">I build reliable, data-driven products that feel delightful.</p>
+        <div class="mt-4 d-flex gap-3 flex-wrap justify-content-center justify-content-md-start">
+          <a href="#contact" class="btn btn-primary btn-pill"><i class="fa-solid fa-message me-2"></i>Get in Touch</a>
+          <a id="resumeBtn" href="assets/resume.pdf" download class="btn btn-outline-light btn-pill d-none"><i class="fa-solid fa-download me-2"></i>Download Resume</a>
+        </div>
+        <div class="social">
+          <a href="mailto:sghmy@missouri.edu" aria-label="Email" data-tooltip="Email"><i class="fa-solid fa-envelope"></i></a>
+          <a href="https://linkedin.com/in/sowmyaguda" target="_blank" rel="noopener" aria-label="LinkedIn" data-tooltip="LinkedIn"><i class="fa-brands fa-linkedin"></i></a>
+          <a href="https://github.com/sowmyaguda" target="_blank" rel="noopener" aria-label="GitHub" data-tooltip="GitHub"><i class="fa-brands fa-github"></i></a>
+          <a href="https://twitter.com/sowmyaguda" target="_blank" rel="noopener" aria-label="Twitter" data-tooltip="Twitter"><i class="fa-brands fa-twitter"></i></a>
+        </div>
       </div>
-      <div class="social">
-        <a href="mailto:sghmy@missouri.edu" aria-label="Email" data-tooltip="Email"><i class="fa-solid fa-envelope"></i></a>
-        <a href="https://linkedin.com/in/sowmyaguda" target="_blank" rel="noopener" aria-label="LinkedIn" data-tooltip="LinkedIn"><i class="fa-brands fa-linkedin"></i></a>
-        <a href="https://github.com/sowmyaguda" target="_blank" rel="noopener" aria-label="GitHub" data-tooltip="GitHub"><i class="fa-brands fa-github"></i></a>
-        <a href="https://twitter.com/sowmyaguda" target="_blank" rel="noopener" aria-label="Twitter" data-tooltip="Twitter"><i class="fa-brands fa-twitter"></i></a>
-      </div>
-      <div class="scroll-indicator">
-        <a href="#about" class="scroll-down">
-          <i class="fa-solid fa-chevron-down"></i>
-        </a>
-      </div>
+      <img class="avatar order-first order-md-last" src="assets/image.png" alt="Sowmya Guda" loading="lazy" width="240" height="240" />
+    </div>
+    <div class="scroll-indicator">
+      <a href="#about" class="scroll-down">
+        <i class="fa-solid fa-chevron-down"></i>
+      </a>
     </div>
   </header>
 

--- a/style.css
+++ b/style.css
@@ -265,9 +265,13 @@ a:hover {
   }
 }
 
+.hero-text {
+  max-width: 600px;
+}
+
 .avatar {
-  width: clamp(180px, 22vw, 260px); 
-  height: clamp(180px, 22vw, 260px); 
+  width: clamp(180px, 22vw, 260px);
+  height: clamp(180px, 22vw, 260px);
   border-radius: 50%;
   border: 3px solid var(--primary);
   box-shadow: 0 0 50px rgba(var(--primary-rgb), 0.5);
@@ -278,6 +282,12 @@ a:hover {
 @keyframes float {
   0%, 100% { transform: translateY(0); }
   50% { transform: translateY(-10px); }
+}
+
+@media (min-width: 768px) {
+  .hero-content .avatar {
+    margin-bottom: 0;
+  }
 }
 
 .hero h1 {


### PR DESCRIPTION
## Summary
- Rework hero section to use a side-by-side layout with text left and image right
- Simplify hero actions to "Get in Touch" and "Download Resume" buttons
- Add responsive styles for avatar spacing and hero text width

## Testing
- `python3 -m http.server 8000 & pid=$!; sleep 1; kill $pid`


------
https://chatgpt.com/codex/tasks/task_e_68a149110940833184c371f8bcee8432